### PR TITLE
Use local firmware

### DIFF
--- a/firmware_versions.md
+++ b/firmware_versions.md
@@ -22,3 +22,16 @@ Model 344682 = Classe100 X16E 2 WIRES / Wi-Fi handsfree video internal unit with
 https://www.homesystems-legrandgroup.com/home/-/productsheets/2595814
 
 - [Version 1.5.1](https://www.homesystems-legrandgroup.com/MatrixENG/liferay/bt_mxLiferayCheckout.jsp?fileFormat=generic&fileName=C100X_010501.fwz&fileId=58107.23188.46381.34528)
+
+
+## Download new firmware from unlocked unit
+
+For the C100X, there has been newer 1.5.4 firmware for some time. Unfortunately this new firmware isn't available for download on the Legrand support page. From what I've been told by Legrand support, new firmware wil not be made available anymore via the website but only using the mobile app notification. In case the new firmware gets released on the legrand site, this file can be updated.
+
+In any case, here is a workaround if you already have an 'unlocked' device.
+
+When a new firmware is available, you'll receive a notification in the mobile app.
+At this time, the new firmware file has already been downloaded by the unit for installation.
+Don't install the new firmware using the app. Instead SCP to the unit, download the firmware, edit it using the scripts in this repo and update the firmware using MyHomeSuite.
+
+- The firmwarefile can be found at /home/bticino/cfg/extra/FW/UPDATE.fwz

--- a/main.py
+++ b/main.py
@@ -36,6 +36,7 @@ class PrepareFirmware():
         self.password3 = 'SMARTDES'
         self.workingdir = None
         self.prtFrmw = None
+        self.useLocalFirmware = None
         self.rootPassword = None
         self.SSHcreation = None
         self.removeSig = None
@@ -57,10 +58,20 @@ class PrepareFirmware():
         else:
             print('Wrong model ❌')
             exit(1)
-
-        # Setup filename
-        version = self.getVersionFromURL()
-        self.filename = f'{self.model}_{version}.fwz'
+            
+        # Ask for firmware file
+        self.useLocalFirmware = input('Do you want to download the firmware [y] or '
+                                 'use an available firmware [n]? (y/n): ')
+        if self.useLocalFirmware == 'y' or self.useLocalFirmware == 'Y':    
+            version = self.getVersionFromURL()
+            self.filename = f'{self.model}_{version}.fwz'
+            print(f'The program will download the firmware: {self.filename}', flush=True)
+        elif self.useLocalFirmware == 'n' or self.useLocalFirmware == 'N':            
+            self.filename = input('Enter the filename in the root directory: ')
+            print(f'We use the firmware on this folder called: {self.filename}', flush=True)
+        else:
+            print('Please use y or n', flush=True)
+            exit(1)
 
         # Ask for root password
         self.rootPassword = input('Enter the BTICINO root '
@@ -110,7 +121,10 @@ class PrepareFirmware():
             exit(1)
 
         self.createTempFolder()
-        self.downloadFirmware()
+        if self.useLocalFirmware == 'y' or self.useLocalFirmware == 'Y':   
+            self.downloadFirmware()
+        else:
+            subprocess.run(['sudo', 'cp', f'{cwd}/{self.filename}', f'{self.workingdir}/{self.filename}'])
         filesinsidelist = self.listFilesZIP()
         self.selectFirmwareFile(filesinsidelist)
         self.unzipFile()
@@ -222,9 +236,9 @@ class PrepareFirmware():
         """Un zip function."""
         print('Unzipping firmware... ', end='', flush=True)
         zip_file = f'{self.workingdir}/{self.filename}'
-        if self.password in zip_file:
+        if self.model == 'C300X':
             password = self.password
-        elif self.password2 in zip_file:
+        elif self.model == 'C100X':
             password = self.password2
         elif self.password3 in zip_file:
             password = self.password3
@@ -480,9 +494,9 @@ class PrepareFirmware():
         a = self.filename
         output = a[:-4] + '_new' + a[-4:]
         zip_file = f'{self.workingdir}/{output}'
-        if self.password in zip_file:
+        if self.model == 'C300X':
             password = self.password
-        elif self.password2 in zip_file:
+        elif self.model == 'C100X':
             password = self.password2
         elif self.password3 in zip_file:
             password = self.password3

--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ class PrepareFirmware():
         self.password3 = 'SMARTDES'
         self.workingdir = None
         self.prtFrmw = None
-        self.useLocalFirmware = None
+        self.useWebFirmware = None
         self.rootPassword = None
         self.SSHcreation = None
         self.removeSig = None
@@ -60,13 +60,13 @@ class PrepareFirmware():
             exit(1)
             
         # Ask for firmware file
-        self.useLocalFirmware = input('Do you want to download the firmware [y] or '
+        self.useWebFirmware = input('Do you want to download the firmware [y] or '
                                  'use an available firmware [n]? (y/n): ')
-        if self.useLocalFirmware == 'y' or self.useLocalFirmware == 'Y':    
+        if self.useWebFirmware == 'y' or self.useWebFirmware == 'Y':    
             version = self.getVersionFromURL()
             self.filename = f'{self.model}_{version}.fwz'
             print(f'The program will download the firmware: {self.filename}', flush=True)
-        elif self.useLocalFirmware == 'n' or self.useLocalFirmware == 'N':            
+        elif self.useWebFirmware == 'n' or self.useWebFirmware == 'N':            
             self.filename = input('Enter the filename in the root directory: ')
             print(f'We use the firmware on this folder called: {self.filename}', flush=True)
         else:
@@ -121,7 +121,7 @@ class PrepareFirmware():
             exit(1)
 
         self.createTempFolder()
-        if self.useLocalFirmware == 'y' or self.useLocalFirmware == 'Y':   
+        if self.useWebFirmware == 'y' or self.useWebFirmware == 'Y':   
             self.downloadFirmware()
         else:
             subprocess.run(['sudo', 'cp', f'{cwd}/{self.filename}', f'{self.workingdir}/{self.filename}'])


### PR DESCRIPTION
I've updated the script to work on a downloaded firmware that is available in the root of the repository.

For my C100X unit, there is a new firmware (1.5.4) that isn't available through the site but I'm able to get it from the unit itself once it gives the 'New firmware available' notification. I've added a bit of info and (minimal) documentation on how to get this firmware update from the device itself.

With the changes to the script, you'll be able to use that file instead of redownloading it every time.