### PR TITLE
Add Support for Firmware Version 1.5.5 and Update README Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ https://www.paypal.com/donate/?business=XQQJHGVPHLD7W&no_recurring=0&item_name=T
 
 ## Firmware preparation and flashing
 
+> If you need to use MQTT, first read [here](/mqtt_scripts/README.md) and insert the required information in TcpDump2Mqtt.conf. More info later
+
 ### 1. Prepare and create firmware via python script
 
 [![asciicast](https://asciinema.org/a/514007.svg)](https://asciinema.org/a/514007)

--- a/main.py
+++ b/main.py
@@ -36,6 +36,12 @@ class PrepareFirmware():
                  'liferay/bt_mxLiferayCheckout.jsp?fileFormat=generic&'
                  'fileName=C100X_010501.fwz&fileId='
                  '58107.23188.46381.34528')
+    # C100X_010505.fwz
+    url_c100x_010505 = ('https://www.homesystems-legrandgroup.com/MatrixENG/'
+                 'liferay/bt_mxLiferayCheckout.jsp?fileFormat=generic&'
+                 'fileName=C100X_010505.fwz&fileId='
+                 '58107.23188.62332.48840')
+    password = 'C300X'
     password = 'C300X'
     password2 = 'C100X'
     password3 = 'SMARTDES'
@@ -111,9 +117,12 @@ class PrepareFirmware():
                         print('Wrong version ❌', flush=True)
                         time.sleep(1)
                 elif self.model == 'c100x':
-                    version = input('Insert version (1.5.1, default 1.5.1 [ENTER]): ')
+                    version = input('Insert version (1.5.1 or 1.5.5, default 1.5.5 [ENTER]): ')
                     if version in ('010501', '1.5.1', ''):
                         self.url = PrepareFirmware.url_c100x_010501
+                        step = 2
+                    elif version in ('010505', '1.5.5', ''):
+                        self.url = PrepareFirmware.url_c100x_010505
                         step = 2
                     else:
                         print('Wrong version ❌', flush=True)

--- a/main.py
+++ b/main.py
@@ -42,7 +42,6 @@ class PrepareFirmware():
                  'fileName=C100X_010505.fwz&fileId='
                  '58107.23188.62332.48840')
     password = 'C300X'
-    password = 'C300X'
     password2 = 'C100X'
     password3 = 'SMARTDES'
 


### PR DESCRIPTION
This pull request includes the following updates:

1. **Firmware Download Support**: Added functionality to the script to enable downloading version 1.5.5 of the firmware for the C100X.
2. **README Update**: Updated the README file to provide clearer instructions on compiling the `TcpDump2Mqtt.conf` before creating the firmware.