### PR TITLE
Fix for Gateway Detection and Temporary Logs

### DIFF
--- a/mqtt_scripts/TcpDump2Mqtt
+++ b/mqtt_scripts/TcpDump2Mqtt
@@ -75,7 +75,12 @@ fi
 
 # Determine and show default gateway
 GWADDR="$(route -n | grep 'UG[ \t]' | awk '{print $2}')"
-echo -n "Default gateway $GWADDR | "
+if [ -z "$GWADDR" ]; then
+	echo "ERROR: Default gateway not found!"
+	exit 1
+fi
+echo "Default gateway resolved as: $GWADDR"
+
 
 # Displays destination MQTT broker
 echo -n "MQTT host $MQTT_HOST"

--- a/mqtt_scripts/TcpDump2Mqtt.sh
+++ b/mqtt_scripts/TcpDump2Mqtt.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-/etc/tcpdump2mqtt/TcpDump2Mqtt &
+/etc/tcpdump2mqtt/TcpDump2Mqtt > /tmp/tcp_log.txt 2>&1 &
 sleep 10
 
 exit 0


### PR DESCRIPTION
I made some changes to how the gateway is detected.
The line:
`GWADDR="$(route -n | grep 'UG[ \t]' | awk '{print $2}')"`
only works if the routing table is already set up. But if the script runs too early, the network might not be ready yet, and route -n returns an empty string.

With this change, the script checks if $GWADDR is empty and exits if it is. Since I added this, I haven't had any more disconnection issues.

I also added some basic logging to /tmp/tcp_log.txt. It’s not persistent because the filesystem is read-only, but it can be useful for debugging.